### PR TITLE
Add local development setup instructions for Mac OS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,15 @@ The Git workflow that the team follows:
 
 
 ## Local Development Environment Setup:
-Coming soon!
+*MacOS Instructions*
+* Download Visual Studio Code and the Prettier extension.
+* Ensure that `npm` and `node` version 14 is installed and used.
+* If you are having EACCES permissions errors when installing `npm` globally, uninstall `npm` by running
+  `sudo npm uninstall npm -g`, then complete the following steps:
+* Run `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash` to install `nvm`.
+* Run `nvm install 14`, then `nvm use 14`. This will install and use the version of `node` that we'll be developing on. 
+* Run `nvm install-latest-npm` to install `npm`, which is the node package manager.
+* Clone this repository, create a branch to work on and you're ready to go! Please follow the Git workflow listed above :)
 
 ## How to Build and Test
 Coming soon!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The Git workflow that the team follows:
 * Rinse and repeat!
 
 
-## Local Development Environment Setup:
+## Local Development Environment Setup
 **MacOS Instructions**
 * Download Visual Studio Code and the Prettier extension.
 * Ensure that `npm` and `node` version 14 is installed and used.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ The Git workflow that the team follows:
 
 
 ## Local Development Environment Setup:
-*MacOS Instructions*
+**MacOS Instructions**
 * Download Visual Studio Code and the Prettier extension.
 * Ensure that `npm` and `node` version 14 is installed and used.
 * If you are having EACCES permissions errors when installing `npm` globally, uninstall `npm` by running


### PR DESCRIPTION
Added instructions for local dev setup for Mac OS, specifically for installing `node` and `npm` using `nvm` to avoid any permissions errors